### PR TITLE
L8D's Node v6+ support, flag initialization fix, memory leak fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/README.md
+++ b/README.md
@@ -1,45 +1,101 @@
-Install:
+# epeg
+Forked from github.com/phorque/node-epeg (with github.com/L8D node v6 support)
 
-```
-npm install epeg
+# My fixes:
+ - Issue with random memory for the "cropped" and "scaled" flags (code otherwise randomly fails)
+ - Improved error messages and documentation.  
+I highly recommend using my fork (this repository) over phorque's and L8D's versions.
+
+# Description
+ - Crop or scale down images with the insanely fast (and commonly used) C library libjpeg
+ - While libjpeg isn't as fast as libjpeg-turbo, it's waaaay faster than anything written in JavaScript
+
+# Dependencies
+ - NodeJS
+ - libjpeg
+
+To install libjpeg:
+- Mac  
+```bash brew install libjpeg ```
+
+- Ubuntu  
+```bash sudo apt-get -y install libjpeg ```
+
+- Windows  
+``` I have absolutely no idea ```
+
+# Install epeg (once libjpeg installed)
+Run this command in your project directory. The --save will add this repository to your package.json
+```bash
+npm install git://github.com/falconscript/node-epeg --save
 ```
 
-Downsize:
 
+# Usage
+
+# Load image binary
+```javascript
+// Load from path - image on disk
+var image = new epeg.Image({path: "./test.jpg"}));
 ```
+OR
+```javascript
+// Load from binary data - after something like fs.readFile
+var image = new epeg.Image({data: imgBinaryBuffer}));
+```
+
+# Crop:
+
+```javascript
 var epeg = require("epeg");
 
-image = new epeg.Image({path: "./test.jpg"}))
-image.downsize(100, 100).saveTo("./output.jpg");
+var pixelsFromLeftToCrop = 100;
+var pixelsFromTopToCrop = 50;
+var newWidth = 200;
+var newHeight = 300;
+
+image = new epeg.Image({path: "./test.jpg"}));
+image.crop(pixelsFromLeftToCrop, pixelsFromTopToCrop, newWidth, newHeight).saveTo("./output.jpg");
 ```
 
-Crop:
+# Downsize:
+Scale an image down
 
-```
+```javascript
 var epeg = require("epeg");
 
-image = new epeg.Image({path: "./test.jpg"}))
-image.crop(200, 200, 100, 100).saveTo("./output.jpg");
+var newWidthInPixels = 150;
+var newHeightInPixels = 50;
+var saveQualityPercent = 90;
+
+image = new epeg.Image({path: "./test.jpg"}));
+image.downsize(newWidthInPixels, newHeightInPixels, saveQualityPercent).saveTo("./ugly.jpg");
 ```
 
-Both can take an optional 'quality' parameter between 1 and 100 (default is 85):
+# Quality parameter
+Note that crop and downsize can take an optional extra 'quality' parameter between 1 and 100 (default is 85)
 
-```
-var epeg = require("epeg");
 
-image = new epeg.Image({path: "./test.jpg"}))
-image.downsize(100, 100, 50).saveTo("./ugly.jpg");
-```
+# To get raw image buffer
+Instead of saving with .saveTo(filename), you can call .process() after downsize/crop
 
-You can also use buffers as I/O:
-
-```
+```javascript
 var fs = require("fs");
 var epeg = require("epeg");
 
 fs.readFile("./test.jpg", function(err, data) {
+  // load the image with the binary buffer
   var image = new epeg.Image({data: data});
-  buffer = image.downsize(100, 100).process();
+  var rawImageBuffer = image.downsize(100, 100).process();
+  
+  // do whatever with the rawImageBuffer, maybe do a phash or something for image similarity?
+  
+  // write changed image to disk
   fs.writeFileSync("./output.jpg", buffer);
-}
+});
 ```
+
+# Credits
+github.com/phorque - Original repository  
+github.com/L8D - added crucial node v6 support  
+github.com/falconscript - fixed memory flag runtime error and added docs

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -33,7 +33,7 @@ Image::Initialize(Local<Object> target)
   Local<FunctionTemplate> constructor = FunctionTemplate::New(isolate, Image::New);
   constructor->InstanceTemplate()->SetInternalFieldCount(1);
   constructor->SetClassName(String::NewFromUtf8(isolate, "Image"));
-
+  
   // Prototype
   Local<ObjectTemplate> proto = constructor->PrototypeTemplate();
 
@@ -63,7 +63,7 @@ void Image::New(const FunctionCallbackInfo<Value> &args)
   image->Wrap(args.This());
 
   if (args.Length() < 1) {
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong number of arguments")));
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "epeg.image.new - Must pass data or path")));
     return;
   }
 
@@ -83,15 +83,22 @@ void Image::New(const FunctionCallbackInfo<Value> &args)
       image->im = epeg_memory_open(buffer, size);
     }
     else {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+          "[!] epeg.image.new - Invalid arguents. Must pass data or path")));
       return;
     }
 
     if (!image->im) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Cannot create image")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "[!] epeg.image.new - Failed to create image")));
       return;
     }
     epeg_size_get(image->im, &(image->width), &(image->height));
+    
+    
+    // Flags must start false
+    image->cropped = false;
+    image->scaled = false;
+
   }
 }
 
@@ -105,14 +112,15 @@ Image::Process(const FunctionCallbackInfo<Value> &args)
 
   Image * image = ObjectWrap::Unwrap<Image>(args.This());
   if (!image->im) {
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Image already updated")));
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+                 "[!] epeg.image.process() - Image was null. Task may already be finished?")));
     return;
   }
 
   epeg_memory_output_set(image->im, &data, &size);
 
   if (image->ProcessInternal() != 0) {
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Could not save to buffer")));
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "[!] epeg.image.process - Could not save to buffer")));
     return;
   }
 
@@ -132,12 +140,14 @@ Image::SaveTo(const FunctionCallbackInfo<Value> &args)
 
   Image * image = ObjectWrap::Unwrap<Image>(args.This());
   if (!image->im) {
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Image already updated")));
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+                  "[!] epeg.image.saveTo - Image was null. Task may already be finished?")));
     return;
   }
 
   if (!args[0]->IsString()) {
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+                  "[!] epeg.image.saveTo - Arg1 must be string path to save")));
     return;
   }
   String::Utf8Value output_file(args[0]->ToString());
@@ -145,7 +155,7 @@ Image::SaveTo(const FunctionCallbackInfo<Value> &args)
   epeg_file_output_set(image->im, *output_file);
 
   if (image->ProcessInternal() != 0) {
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Could not save to file")));
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "[!] epeg.image.saveTo - Could not save to file")));
     return;
   }
 
@@ -161,17 +171,19 @@ Image::Downsize(const FunctionCallbackInfo<Value>& args)
     Isolate* isolate = args.GetIsolate();
     Image * image = ObjectWrap::Unwrap<Image>(args.This());
 
-    // if (image->scaled || image->croped) {
+    // if (image->scaled || image->cropped) {
     //   ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Image already updated")));
     //   return;
     // }
     if (args.Length() < 2) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong number of arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+             "[!] epeg.image.downsize - Downsize expects two arguments!")));
       return;
     }
 
     if (!args[0]->IsInt32() || !args[1]->IsInt32()) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, 
+             "[!] epeg.image.downsize - Downsize arguments must be integers! (Int32)!")));
       return;
     }
 
@@ -179,7 +191,8 @@ Image::Downsize(const FunctionCallbackInfo<Value>& args)
     int height = args[1]->Int32Value();
     if (width < 0 || width > image->width ||
         height < 0 || height > image->height) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, 
+             "[!] epeg.image.downsize - Argument discrepancy! new height/width must be less than old height/width and non-negative!")));
       return;
     }
 
@@ -202,12 +215,18 @@ Image::Crop(const FunctionCallbackInfo<Value>& args)
 
     Image * image = ObjectWrap::Unwrap<Image>(args.This());
 
-    if (image->scaled || image->croped) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Image already updated")));
+    if (image->scaled) {
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+             "[!] epeg.image.crop - Image has already been scaled. So we can't crop. Get buffer with .process() and make new Image")));
+      return;
+    } else if (image->cropped) {
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+             "[!] epeg.image.crop - Image has already been cropped. So we can't crop. Get buffer with .process() and make new Image")));
       return;
     }
     if (args.Length() < 4) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong number of arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+              "[!] epeg.image.crop - Four arguments must be passed to crop: (startX, startY, newWidth, newHeight)")));
       return;
     }
 
@@ -215,7 +234,8 @@ Image::Crop(const FunctionCallbackInfo<Value>& args)
         !args[1]->IsInt32() ||
         !args[2]->IsInt32() ||
         !args[3]->IsInt32()) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, 
+              "[!] epeg.image.crop - Arguments to crop must be integers. (Int32)")));
       return;
     }
 
@@ -227,7 +247,8 @@ Image::Crop(const FunctionCallbackInfo<Value>& args)
 
     if (x < 0 || y < 0 || width < 0 || height < 0 ||
         (x + width) > image->width || (y + height) > image->height) {
-      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Wrong arguments")));
+      isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate,
+               "[!] epeg.image.crop - Discrepancy! Trying to crop outside bounds (or negative argument passed?)")));
       return;
     }
 
@@ -238,7 +259,7 @@ Image::Crop(const FunctionCallbackInfo<Value>& args)
     epeg_quality_set(image->im, quality);
     epeg_decode_bounds_set(image->im, x, y, width, height);
 
-    image->croped = true;
+    image->cropped = true;
     args.GetReturnValue().Set(args.This());
 }
 
@@ -266,7 +287,7 @@ Image::ProcessInternal()
   if (scaled) {
     return epeg_encode(im);
   }
-  else if (croped) {
+  else if (cropped) {
     return epeg_trim(im);
   }
 }

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -2,6 +2,7 @@
 #include <node.h>
 #include <node_buffer.h>
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "Epeg.h"
@@ -129,7 +130,7 @@ Image::Process(const FunctionCallbackInfo<Value> &args)
 
   Local<Value> buffer = node::Buffer::New(isolate, size).ToLocalChecked();
   memcpy(node::Buffer::Data(buffer), data, size);
-
+  free(data); 
   args.GetReturnValue().Set(buffer);
 }
 

--- a/src/Image.h
+++ b/src/Image.h
@@ -35,7 +35,7 @@ class Image: public node::ObjectWrap {
   int           height;
 
   bool          scaled;
-  bool          croped;
+  bool          cropped;
 };
 
 #endif /* __EPEG_IMAGE_H__ */

--- a/src/Image.h
+++ b/src/Image.h
@@ -15,14 +15,14 @@ class Image: public node::ObjectWrap {
   static Persistent<FunctionTemplate> constructor;
   static void Initialize(Handle<Object>);
 
-  static Handle<Value> New(const Arguments &args);
-  static Handle<Value> Downsize(const Arguments &args);
-  static Handle<Value> Crop(const Arguments &args);
-  static Handle<Value> Process(const Arguments &args);
-  static Handle<Value> SaveTo(const Arguments &args);
+  static void New(const FunctionCallbackInfo<Value> &args);
+  static void Downsize(const FunctionCallbackInfo<Value> &args);
+  static void Crop(const FunctionCallbackInfo<Value> &args);
+  static void Process(const FunctionCallbackInfo<Value> &args);
+  static void SaveTo(const FunctionCallbackInfo<Value> &args);
 
-  static Handle<Value> GetWidth(Local<String> prop, const AccessorInfo &info);
-  static Handle<Value> GetHeight(Local<String> prop, const AccessorInfo &info);
+  static void GetWidth(Local<String> prop, const PropertyCallbackInfo<Value> &info);
+  static void GetHeight(Local<String> prop, const PropertyCallbackInfo<Value> &info);
 
   Image();
 


### PR DESCRIPTION
Same as the last pull request plus an additional fix of a memory leak.

After running the module on a large number of images, the memory usage was very very high. Looking at the source, I found that the image "data" has to be freed once handed off to node because the epeg library's image class does not free it

Works really well now!